### PR TITLE
Fix URLs with base tag

### DIFF
--- a/layout.html.twig
+++ b/layout.html.twig
@@ -3,6 +3,7 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
     <head>
+        {{ renderBaseUrlHeader() }}
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta name="apple-mobile-web-app-capable" content="yes" />


### PR DESCRIPTION
This fixes #36. Currently, URLs linking to other classes are broken. This adds the correct base tag and thus fixes the URLs.